### PR TITLE
Update server.py for Python3

### DIFF
--- a/pypxe/server.py
+++ b/pypxe/server.py
@@ -161,7 +161,7 @@ def main():
             except ValueError:
                 sys.exit('{0} does not contain valid JSON'.format(args.JSON_CONFIG))
             for setting in loaded_config:
-                if type(loaded_config[setting]) is unicode:
+                if type(loaded_config[setting]) is str:
                     loaded_config[setting] = loaded_config[setting].encode('ascii')
             SETTINGS.update(loaded_config) # update settings with JSON config
             args = parse_cli_arguments() # re-parse, CLI options take precedence


### PR DESCRIPTION
Python3 did away with the 'unicode' tag renaming in 'str'. This causes PyPXE in python 3 to bail out if we load a JSON config.

Ref: https://stackoverflow.com/questions/19877306/nameerror-global-name-unicode-is-not-defined-in-python-3

Error: Traceback (most recent call last):
  File "/usr/local/bin/pypxe", line 8, in <module>
    sys.exit(main())
  File "/usr/local/lib/python3.6/site-packages/pypxe/server.py", line 164, in main
    if type(loaded_config[setting]) is unicode:
NameError: name 'unicode' is not defined