### PR TITLE
Fix an embarrassing mistake

### DIFF
--- a/pypxe/server.py
+++ b/pypxe/server.py
@@ -161,7 +161,7 @@ def main():
             except ValueError:
                 sys.exit('{0} does not contain valid JSON'.format(args.JSON_CONFIG))
             for setting in loaded_config:
-                if type(loaded_config[setting]) is str:
+                if type(loaded_config[setting]) is bytes:
                     loaded_config[setting] = loaded_config[setting].encode('ascii')
             SETTINGS.update(loaded_config) # update settings with JSON config
             args = parse_cli_arguments() # re-parse, CLI options take precedence


### PR DESCRIPTION
My sincere apologies. My previous "fix" missed the point of the the conversion in the first place. we expect all JSON values to be Strings or Bools so we encode bytes into string. This blunder would only have been apparent if someone loaded a JSON config.