### PR TITLE
docs: Fix a few typos

### DIFF
--- a/pypxe/nbd/writes.py
+++ b/pypxe/nbd/writes.py
@@ -12,13 +12,13 @@ class COW:
         length -= 4096 - (offset % 4096)
         offset += 4096
 
-        # all following FULL chunks, definate page boundary and full size
+        # all following FULL chunks, definite page boundary and full size
         while length >= 4096:
             basepages.append((offset, 0, 4096))
             length -= 4096
             offset += 4096
 
-        # final non-full chunk, definate offset, variable length
+        # final non-full chunk, definite offset, variable length
         if length > 0:
             basepages.append((offset, 0, length))
 
@@ -90,7 +90,7 @@ class DiskCOW(COW):
         self.logger = helpers.get_child_logger(logger, 'FS')
         self.logger.info('Copy-On-Write for {addr} in PyPXE_NBD_COW_{addr[0]}_{addr[1]}'.format(addr = addr))
 
-        # never want readonly cow, also definately creating file
+        # never want readonly cow, also definitely creating file
         self.fh = open('PyPXE_NBD_COW_{addr[0]}_{addr[1]}'.format(addr = addr), 'w+b')
 
         # pages is a list of the addresses for which we have different pages

--- a/pypxe/server.py
+++ b/pypxe/server.py
@@ -201,7 +201,7 @@ def main():
         if args.USE_HTTP and not args.USE_IPXE and not args.USE_DHCP:
             sys_logger.warning('HTTP selected but iPXE disabled. PXE ROM must support HTTP requests.')
 
-        # if the argument was pased to enabled ProxyDHCP then enable the DHCP server
+        # if the argument was passed to enabled ProxyDHCP then enable the DHCP server
         if args.DHCP_MODE_PROXY:
             args.USE_DHCP = True
 


### PR DESCRIPTION
There are small typos in:
- pypxe/nbd/writes.py
- pypxe/server.py

Fixes:
- Should read `definite` rather than `definate`.
- Should read `passed` rather than `pased`.
- Should read `definitely` rather than `definately`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md