### PR TITLE
pypxe/dhcp.py: avoid exception when invoking export_leases

### DIFF
--- a/pypxe/dhcp.py
+++ b/pypxe/dhcp.py
@@ -141,7 +141,7 @@ class DHCPD:
             for lease in self.leases:
                 # translate the key to json safe (and human readable) mac
                 export_safe[self.get_mac(lease)] = self.leases[lease]
-            leases_file = open(self.save_leases_file, 'wb')
+            leases_file = open(self.save_leases_file, 'w')
             json.dump(export_safe, leases_file)
             self.logger.info('Exported leases to {0}'.format(self.save_leases_file))
 


### PR DESCRIPTION
Fixes the following crash:

Traceback (most recent call last):

  [...]

  File "/usr/lib/python3.10/site-packages/pypxe/dhcp.py", line 145, in export_leases
    json.dump(export_safe, leases_file)
  File "/usr/lib/python3.10/json/__init__.py", line 180, in dump
    fp.write(chunk)
TypeError: a bytes-like object is required, not str